### PR TITLE
Swap FILTER_SANITIZE_STRING to FILTER_UNSAFE_RAW

### DIFF
--- a/modify-comment-parent.php
+++ b/modify-comment-parent.php
@@ -56,7 +56,7 @@ function fe_mcp_add_meta_box_callback( $comment ) {
 function fe_mcp_update_comment_parent() {
 	$comment_parent = intval( filter_input( INPUT_POST, 'fe_mcp_parent_comment_id', FILTER_VALIDATE_INT ) );
 	$comment_id     = intval( filter_input( INPUT_POST, 'comment_ID', FILTER_VALIDATE_INT ) );
-	$nonce          = filter_input( INPUT_POST, 'fe_modify_comment_parent_nonce', FILTER_SANITIZE_STRING );
+	$nonce          = filter_input( INPUT_POST, 'fe_modify_comment_parent_nonce', FILTER_UNSAFE_RAW );
 
 	if ( ! $comment_id ) {
 		// We don't have a comment to modify, make no changes.

--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,9 @@ Please report bugs at https://github.com/salcode/modify-comment-parent/issues
 
 == Changelog ==
 
+= Unreleased =
+* Replace `FILTER_SANITIZE_STRING` with `FILTER_UNSAFE_RAW` ([#2](https://github.com/salcode/modify-comment-parent/issues/2))
+
 = 1.0.1 =
 * Increase text input box width. Previously, it was too narrow for large numbers.
 


### PR DESCRIPTION
The FILTER_SANITIZE_STRING filter is deprecated as of PHP 8.1

Reviewing this code, it was determined the $nonce variable is used exclusively as an argument for wp_verify_nonce(), which does not require a filtered value.

Based on this, we're now using the FILTER_UNSAFE_RAW filter, which makes no changes to the value but allows us to keep using the filter_input() function here (like we do for other values).

Resolves #2