### PR TITLE
Bump "Tested up to" value to 6.7

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: salcode
 Tags: comment
 Requires at least: 3.6
-Tested up to: 4.7
+Tested up to: 6.7
 Stable tag: trunk
 License: Apache License, Version 2.0
 License URI: http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Typically, the "Tested up to" value is incremented outside of this Git repository as per the instructions on
https://salferrarello.com/increase-tested-up-to-value-for-wordpress-plugin/#trunk-based

However, since we're already creating a release, it makes sense to bump this value at this time, as well.