### PR TITLE
Remove extraneous return $post_id

### DIFF
--- a/modify-comment-parent.php
+++ b/modify-comment-parent.php
@@ -65,7 +65,7 @@ function fe_mcp_update_comment_parent() {
 
 	if ( ! $nonce ) {
 		// We do not have a nonce value, make no changes.
-		return $post_id;
+		return;
 	}
 
 	if ( ! wp_verify_nonce( $nonce, 'fe_modify_comment_parent' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,9 @@ Please report bugs at https://github.com/salcode/modify-comment-parent/issues
 
 == Changelog ==
 
+= Unreleased =
+* Remove extraneous `return $post_id;` to prevent PHP Warning `Undefined variable $post_id` ([#6](https://github.com/salcode/modify-comment-parent/issues/6))
+
 = 1.0.2 =
 * Replace `FILTER_SANITIZE_STRING` with `FILTER_UNSAFE_RAW` ([#2](https://github.com/salcode/modify-comment-parent/issues/2))
 


### PR DESCRIPTION
Remove extraneous return $post_id to prevent
PHP Warning "Undefined variable $post_id"

Resolves #6